### PR TITLE
Ensure "fields" config is optional

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -200,7 +200,7 @@ async function getDocumentsMetadata({auth, foldersIds, fields, fieldsMapper}) {
           q: `${foldersIds
             .map(id => `'${id}' in parents`)
             .join(" or ")} and mimeType='application/vnd.google-apps.document'`,
-          fields: `files(id, name, ${fields.join(", ")})`,
+          fields: `files(id, name${fields ? `, ${fields.join(", ")}` : ""})`,
         },
         (err, res) => {
           if (err) {


### PR DESCRIPTION
According to the documentation, the `fields` and `fieldsMapper` options should be optional. However, when excluded, the following error is given when attempting to run `gatsby develop`: 

```
error Plugin gatsby-source-google-docs returned an error
  Error: source-google-docs: Cannot read property 'join' of undefined  
  - gatsby-node.js:280 Object.exports.sourceNodes
    [gatsby-site]/[gatsby-source-google-docs]/gatsby-node.js:280:10
```

Tracing this error lead to line 203 of `gatsby-node.js` in `src`: 

```js
fields: `files(id, name, ${fields.join(", ")})`,
```

This code works great when the fields option is defined, but when the parameter is undefined, an error is thrown when attempting to use `.join()` on the undefined parameter. 

To fix this, I simply suggest checking to see if `fields` is undefined (by checking its truthiness). 
Originally, I tried this solution:

```js
fields: `files(id, name, ${fields ? fields.join(", ") : ""})`,
```

However, this threw another error: 

```
error Plugin gatsby-source-google-docs returned an error
  Error: source-google-docs: Invalid field selection files(id, name, )
  - gatsby-node.js:280 Object.exports.sourceNodes
    [gatsby-site]/[gatsby-source-google-docs]/gatsby-node.js:280:10
```

To resolve this error, I modified the line as such:

```js
fields: `files(id, name${fields ? `, ${fields.join(", ")}` : ""})`,
```

This worked for me and removed the error. Please let me know how this works for you, @xuopled 
If you have any questions, let me know. I only tested this with my scenario, so I think it would be good to test with other Gatsby examples.

Love this plugin by the way. Cheers and thanks!
 — David