### PR TITLE
"yarn dev" only works if there's a "dev" npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ npm install gatsby-source-google-docs --save
 
 ### Generate a token file
 
-Run `yarn dev` to generate a token file.
+Run `gatsby develop` to generate a token file.
 
 > `token_path` can be customized in the configuration object.
 


### PR DESCRIPTION
"gatsby develop" is more universal and what we suggest people use for starting the development server.