### PR TITLE
fix getAuth() in auth.js

### DIFF
--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -35,7 +35,7 @@ async function getAuth({
     redirect_uris[0]
   )
 
-  const token = await getToken(tokenProps)
+  const token = await getToken({...tokenProps, client})
 
   client.setCredentials(token)
   return client


### PR DESCRIPTION
Fix Error: source-google-docs: Cannot read property 'generateAuthUrl' of undefined